### PR TITLE
Enhance single-player world AI and respawns

### DIFF
--- a/client/js/app.js
+++ b/client/js/app.js
@@ -1,5 +1,5 @@
 
-define(['jquery', 'storage'], function($, Storage) {
+define(['jquery', 'storage', 'singleplayer/settings'], function($, Storage, SingleplayerSettings) {
 
     var App = Class.extend({
         init: function() {
@@ -87,19 +87,28 @@ define(['jquery', 'storage'], function($, Storage) {
             
             if(username && !this.game.started) {
                 var optionsSet = false,
-                    config = this.config;
+                    config = this.config,
+                    singlePlayer = SingleplayerSettings.isEnabled();
+
+                if(singlePlayer) {
+                    log.debug("Starting game in single-player mode.");
+                    this.game.enableSinglePlayer(username);
+                    optionsSet = true;
+                }
 
                 //>>includeStart("devHost", pragmas.devHost);
-                if(config.local) {
-                    log.debug("Starting game with local dev config.");
-                    this.game.setServerOptions(config.local.host, config.local.port, username);
-                } else {
-                    log.debug("Starting game with default dev config.");
-                    this.game.setServerOptions(config.dev.host, config.dev.port, username);
+                if(!optionsSet) {
+                    if(config.local) {
+                        log.debug("Starting game with local dev config.");
+                        this.game.setServerOptions(config.local.host, config.local.port, username);
+                    } else {
+                        log.debug("Starting game with default dev config.");
+                        this.game.setServerOptions(config.dev.host, config.dev.port, username);
+                    }
+                    optionsSet = true;
                 }
-                optionsSet = true;
                 //>>includeEnd("devHost");
-                
+
                 //>>includeStart("prodHost", pragmas.prodHost);
                 if(!optionsSet) {
                     log.debug("Starting game with build config.");

--- a/client/js/singleplayer/localgameclient.js
+++ b/client/js/singleplayer/localgameclient.js
@@ -1,0 +1,109 @@
+define(['gameclient', 'singleplayer/world', '../../shared/js/gametypes'],
+function(GameClient, LocalWorld, Types) {
+
+    var LocalGameClient = GameClient.extend({
+        init: function(host, port, options) {
+            this._super(host, port);
+            options = options || {};
+            var self = this;
+
+            options.push = function(messages) {
+                self._dispatch(messages);
+            };
+
+            this.world = new LocalWorld(options);
+            this.playerId = null;
+        },
+
+        connect: function() {
+            var self = this;
+            setTimeout(function() {
+                if(self.connected_callback) {
+                    self.connected_callback();
+                }
+            }, 0);
+        },
+
+        sendMessage: function(message) {
+            var action = message[0];
+
+            switch(action) {
+                case Types.Messages.HELLO:
+                    this._handleHello(message);
+                    break;
+                case Types.Messages.WHO:
+                    this._dispatch(this.world.getSpawnsFor(message.slice(1)));
+                    break;
+                case Types.Messages.MOVE:
+                    this._dispatch(this.world.handleMove(this.playerId, message[1], message[2]));
+                    break;
+                case Types.Messages.LOOTMOVE:
+                    this._dispatch(this.world.handleLootMove(this.playerId, message[1], message[2], message[3]));
+                    break;
+                case Types.Messages.AGGRO:
+                    this._dispatch(this.world.handleAggro(message[1]));
+                    break;
+                case Types.Messages.ATTACK:
+                    this._dispatch(this.world.handleAttack(this.playerId, message[1]));
+                    break;
+                case Types.Messages.HIT:
+                    this._dispatch(this.world.handleHit(this.playerId, message[1]));
+                    break;
+                case Types.Messages.HURT:
+                    this._dispatch(this.world.handleHurt(message[1]));
+                    break;
+                case Types.Messages.LOOT:
+                    this._dispatch(this.world.handleLoot(this.playerId, message[1]));
+                    break;
+                case Types.Messages.TELEPORT:
+                    this._dispatch(this.world.handleTeleport(this.playerId, message[1], message[2]));
+                    break;
+                case Types.Messages.ZONE:
+                    this._dispatch(this.world.handleZone(this.playerId));
+                    break;
+                case Types.Messages.CHAT:
+                    this._dispatch(this.world.handleChat(this.playerId, message[1]));
+                    break;
+                case Types.Messages.OPEN:
+                    this._dispatch(this.world.handleOpen(this.playerId, message[1]));
+                    break;
+                case Types.Messages.CHECK:
+                    this._dispatch(this.world.handleCheck(message[1]));
+                    break;
+                default:
+                    log.debug('LocalGameClient: unhandled message ' + action);
+            }
+        },
+
+        _handleHello: function(message) {
+            var payload = this.world.handleHello(message[1], message[2], message[3]);
+            this.playerId = payload.id;
+
+            this._dispatch([[Types.Messages.WELCOME, payload.id, payload.name, payload.x, payload.y, payload.hp],
+                            [Types.Messages.POPULATION, payload.worldPopulation, payload.totalPopulation]]);
+
+            var list = payload.entityIds.slice(0);
+            list.unshift(Types.Messages.LIST);
+            this._dispatch([list]);
+        },
+
+        _dispatch: function(messages) {
+            var self = this;
+
+            if(!messages) {
+                return;
+            }
+            if(messages.length && messages[0] && !(messages[0] instanceof Array)) {
+                messages = [messages];
+            }
+
+            _.each(messages, function(packet) {
+                if(packet && packet.length) {
+                    self.receiveAction(packet);
+                }
+            });
+        }
+    });
+
+    return LocalGameClient;
+});

--- a/client/js/singleplayer/settings.js
+++ b/client/js/singleplayer/settings.js
@@ -1,0 +1,59 @@
+define(function() {
+
+    var cached = null,
+        STORAGE_KEY = 'bq-singleplayer';
+
+    function parseQuery() {
+        var query = window.location.search || '',
+            hash = window.location.hash || '',
+            pattern = /singleplayer\s*=\s*(1|true|yes)/i;
+
+        if(pattern.test(query) || pattern.test(hash)) {
+            return true;
+        }
+        return false;
+    }
+
+    function readStoredPreference() {
+        try {
+            if(window.localStorage) {
+                var value = window.localStorage.getItem(STORAGE_KEY);
+                if(value === '1' || value === 'true') {
+                    return true;
+                }
+            }
+        } catch(e) {
+            // Access to localStorage can throw in some environments (privacy mode). Ignore and fallback to defaults.
+        }
+        return false;
+    }
+
+    function rememberPreference(enabled) {
+        try {
+            if(window.localStorage) {
+                if(enabled) {
+                    window.localStorage.setItem(STORAGE_KEY, '1');
+                } else {
+                    window.localStorage.removeItem(STORAGE_KEY);
+                }
+            }
+        } catch(e) {
+            // Ignore persistence errors and rely solely on runtime detection.
+        }
+    }
+
+    function isEnabled() {
+        if(cached === null) {
+            cached = parseQuery() || readStoredPreference();
+        }
+        return cached;
+    }
+
+    return {
+        isEnabled: isEnabled,
+        remember: function(enabled) {
+            cached = !!enabled;
+            rememberPreference(cached);
+        }
+    };
+});

--- a/client/js/singleplayer/world.js
+++ b/client/js/singleplayer/world.js
@@ -1,0 +1,741 @@
+define(['../../shared/js/gametypes'], function(Types) {
+
+    var DEFAULTS = {
+        spawn: { x: 65, y: 66 },
+        mobs: [
+            { kind: Types.Entities.RAT, x: 70, y: 68, maxHp: 20, damage: 6, loot: [Types.Entities.FLASK], respawnDelay: 8000 },
+            { kind: Types.Entities.GOBLIN, x: 76, y: 72, maxHp: 35, damage: 9, loot: [Types.Entities.AXE], respawnDelay: 12000 },
+            { kind: Types.Entities.SKELETON, x: 82, y: 69, maxHp: 30, damage: 8, loot: [Types.Entities.MAILARMOR], respawnDelay: 16000 }
+        ],
+        npcs: [
+            { kind: Types.Entities.GUARD, x: 60, y: 64, orientation: Types.Orientations.DOWN },
+            { kind: Types.Entities.VILLAGER, x: 62, y: 68, orientation: Types.Orientations.RIGHT },
+            { kind: Types.Entities.PRIEST, x: 67, y: 61, orientation: Types.Orientations.DOWN }
+        ],
+        chests: [
+            { x: 74, y: 67, loot: [Types.Entities.BURGER, Types.Entities.FLASK] },
+            { x: 80, y: 74, loot: [Types.Entities.CAKE, Types.Entities.REDARMOR] }
+        ]
+    };
+
+    function sanitizeName(name) {
+        var value = (name || '').replace(/<[^>]*>/g, '');
+        value = value.replace(/[^A-Za-z0-9 _-]/g, ' ');
+        value = value.replace(/\s+/g, ' ').replace(/^\s+|\s+$/g, '');
+        if(value.length === 0) {
+            value = 'wanderer';
+        }
+        if(value.length > 15) {
+            value = value.substr(0, 15);
+        }
+        return value;
+    }
+
+    function sanitizeChat(text) {
+        var value = (text || '').replace(/<[^>]*>/g, '');
+        value = value.replace(/\s+/g, ' ').replace(/^\s+|\s+$/g, '');
+        if(value.length > 60) {
+            value = value.substr(0, 60);
+        }
+        return value;
+    }
+
+    var LocalWorld = Class.extend({
+        init: function(options) {
+            options = options || {};
+            this.map = options.map || null;
+            this.storage = options.storage || null;
+            this.pushCallback = options.push || null;
+
+            this.spawn = options.spawn || DEFAULTS.spawn;
+            this.templates = options.templates || DEFAULTS;
+
+            this.tickRate = options.tickRate || 200;
+            this.mobAggroRange = options.mobAggroRange || 6;
+            this.mobLeashRange = options.mobLeashRange || 12;
+            this.mobAttackDelay = options.mobAttackDelay || 900;
+            this.regenInterval = options.regenInterval || 2000;
+            this.chestRespawnDelay = options.chestRespawnDelay || 45000;
+
+            this.player = null;
+            this.entities = {};
+            this.mobs = {};
+            this.npcs = {};
+            this.items = {};
+            this.chests = {};
+            this.mobRespawnTimers = {};
+            this.chestRespawnTimers = {};
+            this.nextEntityId = 2;
+            this.tickTimer = null;
+            this.regenTimer = null;
+
+            this._populateStatics();
+            this._startLoops();
+        },
+
+        handleHello: function(name, armorKind, weaponKind) {
+            if(!armorKind) {
+                armorKind = Types.Entities.CLOTHARMOR;
+            }
+            if(!weaponKind) {
+                weaponKind = Types.Entities.SWORD1;
+            }
+
+            var spawn = this.spawn || { x: 10, y: 10 };
+            this.player = {
+                id: 1,
+                type: 'player',
+                kind: Types.Entities.WARRIOR,
+                name: sanitizeName(name),
+                x: spawn.x,
+                y: spawn.y,
+                orientation: Types.Orientations.DOWN,
+                armor: armorKind,
+                weapon: weaponKind,
+                maxHp: this._computePlayerMaxHp(armorKind),
+                hp: this._computePlayerMaxHp(armorKind),
+                target: null,
+                checkpoint: null
+            };
+            this.entities[this.player.id] = this.player;
+
+            return {
+                id: this.player.id,
+                name: this.player.name,
+                x: this.player.x,
+                y: this.player.y,
+                hp: this.player.hp,
+                worldPopulation: 1,
+                totalPopulation: 1,
+                entityIds: this.buildEntityList()
+            };
+        },
+
+        buildEntityList: function() {
+            return _.chain(this.entities)
+                    .keys()
+                    .map(function(id) { return parseInt(id, 10); })
+                    .reject(function(id) { return id === 1; })
+                    .value();
+        },
+
+        getSpawnsFor: function(ids) {
+            var self = this,
+                packets = [];
+
+            _.each(ids, function(id) {
+                var entityId = parseInt(id, 10);
+                if(entityId === 1 && self.player) {
+                    packets.push(self._serializePlayer(self.player));
+                } else {
+                    var entity = self.entities[entityId];
+                    if(entity) {
+                        packets.push(self._serializeEntity(entity));
+                    }
+                }
+            });
+
+            return packets;
+        },
+
+        handleMove: function(playerId, x, y) {
+            var packets = [];
+            if(this.player && this._isValidPosition(x, y)) {
+                this.player.x = x;
+                this.player.y = y;
+                this.player.target = null;
+                packets.push([Types.Messages.MOVE, this.player.id, x, y]);
+            }
+            return packets;
+        },
+
+        handleLootMove: function(playerId, x, y, itemId) {
+            var packets = this.handleMove(playerId, x, y);
+            if(this.player && itemId && this.items[itemId]) {
+                packets.push([Types.Messages.LOOTMOVE, this.player.id, parseInt(itemId, 10)]);
+            }
+            return packets;
+        },
+
+        handleAttack: function(playerId, targetId) {
+            var packets = [];
+            var target = this.entities[targetId];
+            if(this.player && target && target.type === 'mob') {
+                this.player.target = target.id;
+                target.target = this.player.id;
+                packets.push([Types.Messages.ATTACK, this.player.id, target.id]);
+            }
+            return packets;
+        },
+
+        handleAggro: function(mobId) {
+            var mob = this.mobs[mobId];
+            if(mob && this.player) {
+                mob.target = this.player.id;
+                this._push([[Types.Messages.ATTACK, mob.id, this.player.id]]);
+            }
+            return [];
+        },
+
+        handleHit: function(playerId, targetId) {
+            var self = this,
+                mob = this.mobs[targetId],
+                packets = [];
+
+            if(mob && !mob.isDead) {
+                var damage = this._computePlayerDamage(this.player.weapon, mob.armor);
+                mob.hp = Math.max(0, mob.hp - damage);
+                packets.push([Types.Messages.DAMAGE, mob.id, damage]);
+
+                if(mob.hp === 0) {
+                    mob.isDead = true;
+                    packets.push([Types.Messages.KILL, mob.kind]);
+                    packets.push([Types.Messages.DESPAWN, mob.id]);
+                    this._removeMob(mob);
+
+                    var drops = this._dropForMob(mob);
+                    _.each(drops, function(drop) {
+                        packets.push([Types.Messages.DROP, mob.id, drop.id, drop.kind, [self.player.id]]);
+                    });
+                }
+            }
+
+            return packets;
+        },
+
+        handleHurt: function(attackerId) {
+            var packets = [];
+            var mob = this.mobs[attackerId];
+
+            if(mob && this.player) {
+                var damage = this._computeMobDamage(mob.damage, this.player.armor);
+                this.player.hp = Math.max(0, this.player.hp - damage);
+                packets.push([Types.Messages.HEALTH, this.player.hp]);
+
+                if(this.player.hp === 0) {
+                    this._handlePlayerDeath(packets);
+                }
+            }
+
+            return packets;
+        },
+
+        handleLoot: function(playerId, itemId) {
+            var packets = [],
+                id = parseInt(itemId, 10),
+                item = this.items[id];
+
+            if(item) {
+                packets.push([Types.Messages.DESTROY, item.id]);
+                delete this.items[item.id];
+                delete this.entities[item.id];
+
+                if(Types.isArmor(item.kind)) {
+                    this.player.armor = item.kind;
+                    this.player.maxHp = this._computePlayerMaxHp(item.kind);
+                    this.player.hp = this.player.maxHp;
+                    packets.push([Types.Messages.EQUIP, this.player.id, item.kind]);
+                    packets.push([Types.Messages.HP, this.player.maxHp]);
+                } else if(Types.isWeapon(item.kind)) {
+                    this.player.weapon = item.kind;
+                    packets.push([Types.Messages.EQUIP, this.player.id, item.kind]);
+                } else if(Types.isHealingItem(item.kind)) {
+                    this._healPlayer(this._healingAmount(item.kind));
+                    packets.push([Types.Messages.HEALTH, this.player.hp, 1]);
+                }
+            }
+
+            return packets;
+        },
+
+        handleOpen: function(playerId, chestId) {
+            var self = this,
+                packets = [],
+                id = parseInt(chestId, 10),
+                chest = this.chests[id];
+
+            if(chest) {
+                packets.push([Types.Messages.DESPAWN, chest.id]);
+                delete this.chests[chest.id];
+                delete this.entities[chest.id];
+
+                var drops = this._nextChestItems(chest);
+                _.each(drops, function(kind) {
+                    var item = self._spawnItem(kind, chest.x, chest.y, [playerId]);
+                    packets.push([Types.Messages.DROP, chest.id, item.id, item.kind, [playerId]]);
+                });
+
+                this._scheduleChestRespawn(chest.template || chest, chest.respawnDelay);
+            }
+
+            return packets;
+        },
+
+        handleTeleport: function(playerId, x, y) {
+            var packets = [];
+            if(this.player && this._isValidPosition(x, y)) {
+                this.player.x = x;
+                this.player.y = y;
+                this.player.target = null;
+                packets.push([Types.Messages.TELEPORT, this.player.id, x, y]);
+            }
+            return packets;
+        },
+
+        handleZone: function(playerId) {
+            var list = this.buildEntityList();
+            list.unshift(Types.Messages.LIST);
+            return [list];
+        },
+
+        handleChat: function(playerId, message) {
+            var text = sanitizeChat(message);
+            if(text && text.length > 0) {
+                return [[Types.Messages.CHAT, this.player.id, text]];
+            }
+            return [];
+        },
+
+        handleCheck: function(checkpointId) {
+            if(this.player) {
+                this.player.checkpoint = checkpointId;
+            }
+            return [];
+        },
+
+        destroy: function() {
+            var self = this;
+            if(this.tickTimer) {
+                clearInterval(this.tickTimer);
+                this.tickTimer = null;
+            }
+            if(this.regenTimer) {
+                clearInterval(this.regenTimer);
+                this.regenTimer = null;
+            }
+            _.each(this.mobRespawnTimers, function(timer, key) {
+                if(timer) {
+                    clearTimeout(timer);
+                }
+                delete self.mobRespawnTimers[key];
+            });
+            _.each(this.chestRespawnTimers, function(timer, key) {
+                if(timer) {
+                    clearTimeout(timer);
+                }
+                delete self.chestRespawnTimers[key];
+            });
+        },
+
+        _populateStatics: function() {
+            var self = this,
+                templates = this.templates || DEFAULTS;
+
+            _.each(templates.npcs || [], function(npc) {
+                self._spawnNpc(npc);
+            });
+            _.each(templates.mobs || [], function(mob) {
+                self._spawnMob(mob);
+            });
+            _.each(templates.chests || [], function(chest) {
+                self._spawnChest(chest);
+            });
+        },
+
+        _startLoops: function() {
+            var self = this;
+            if(!this.tickTimer) {
+                this.tickTimer = setInterval(function() {
+                    self._tick();
+                }, this.tickRate);
+            }
+            if(!this.regenTimer) {
+                this.regenTimer = setInterval(function() {
+                    self._regenTick();
+                }, this.regenInterval);
+            }
+        },
+
+        _tick: function() {
+            if(!this.player) {
+                return;
+            }
+            this._updateMobs();
+        },
+
+        _regenTick: function() {
+            if(this.player && this.player.hp < this.player.maxHp) {
+                var amount = Math.max(1, Math.floor(this.player.maxHp / 25));
+                this.player.hp = Math.min(this.player.maxHp, this.player.hp + amount);
+                this._push([[Types.Messages.HEALTH, this.player.hp, 1]]);
+            }
+        },
+
+        _spawnNpc: function(data) {
+            var id = this._nextEntityId();
+            var npc = {
+                id: id,
+                type: 'npc',
+                kind: data.kind,
+                x: data.x,
+                y: data.y,
+                orientation: data.orientation || Types.Orientations.DOWN
+            };
+            this.npcs[id] = npc;
+            this.entities[id] = npc;
+            return npc;
+        },
+
+        _spawnMob: function(data) {
+            var id = this._nextEntityId();
+            var mob = {
+                id: id,
+                type: 'mob',
+                kind: data.kind,
+                x: data.x,
+                y: data.y,
+                orientation: data.orientation || Types.Orientations.DOWN,
+                maxHp: data.maxHp || 30,
+                hp: data.maxHp || 30,
+                armor: data.armor || 4,
+                damage: data.damage || 6,
+                loot: data.loot || [],
+                lootIndex: 0,
+                respawnDelay: data.respawnDelay || 12000,
+                template: data,
+                spawnX: data.x,
+                spawnY: data.y,
+                aggroRange: data.aggroRange || this.mobAggroRange,
+                leashRange: data.leashRange || this.mobLeashRange,
+                attackDelay: data.attackDelay || this.mobAttackDelay,
+                nextAttackTime: 0
+            };
+            this.mobs[id] = mob;
+            this.entities[id] = mob;
+            return mob;
+        },
+
+        _spawnChest: function(data) {
+            var id = this._nextEntityId();
+            var chest = {
+                id: id,
+                type: 'chest',
+                kind: Types.Entities.CHEST,
+                x: data.x,
+                y: data.y,
+                loot: data.loot || [],
+                lootIndex: 0,
+                respawnDelay: data.respawnDelay || this.chestRespawnDelay,
+                template: data
+            };
+            this.chests[id] = chest;
+            this.entities[id] = chest;
+            return chest;
+        },
+
+        _spawnItem: function(kind, x, y, players) {
+            var id = this._nextEntityId();
+            var item = {
+                id: id,
+                type: 'item',
+                kind: kind,
+                x: x,
+                y: y,
+                players: players || []
+            };
+            this.items[id] = item;
+            this.entities[id] = item;
+            return item;
+        },
+
+        _serializePlayer: function(player) {
+            var state = [Types.Messages.SPAWN,
+                         player.id,
+                         player.kind,
+                         player.x,
+                         player.y,
+                         player.name,
+                         player.orientation,
+                         player.armor,
+                         player.weapon];
+            if(player.target) {
+                state.push(player.target);
+            }
+            return state;
+        },
+
+        _serializeEntity: function(entity) {
+            var state = [Types.Messages.SPAWN,
+                         entity.id,
+                         entity.kind,
+                         entity.x,
+                         entity.y];
+            if(entity.type === 'mob') {
+                state.push(entity.orientation);
+                if(entity.target) {
+                    state.push(entity.target);
+                }
+            }
+            return state;
+        },
+
+        _removeMob: function(mob) {
+            delete this.entities[mob.id];
+            delete this.mobs[mob.id];
+            this._scheduleMobRespawn(mob.template, mob.respawnDelay);
+        },
+
+        _scheduleMobRespawn: function(template, delay) {
+            var self = this;
+            if(!template) {
+                return;
+            }
+            var respawnDelay = delay || template.respawnDelay || 12000;
+            var key = template.kind + ':' + template.x + ':' + template.y;
+            if(this.mobRespawnTimers[key]) {
+                clearTimeout(this.mobRespawnTimers[key]);
+            }
+            this.mobRespawnTimers[key] = setTimeout(function() {
+                delete self.mobRespawnTimers[key];
+                var mob = self._spawnMob(template);
+                self._push([[Types.Messages.SPAWN,
+                              mob.id,
+                              mob.kind,
+                              mob.x,
+                              mob.y,
+                              mob.orientation]]);
+            }, respawnDelay);
+        },
+
+        _scheduleChestRespawn: function(template, delay) {
+            var self = this;
+            if(!template) {
+                return;
+            }
+            var respawnDelay = delay || template.respawnDelay || this.chestRespawnDelay;
+            var key = template.x + ':' + template.y;
+            if(this.chestRespawnTimers[key]) {
+                clearTimeout(this.chestRespawnTimers[key]);
+            }
+            this.chestRespawnTimers[key] = setTimeout(function() {
+                delete self.chestRespawnTimers[key];
+                var chest = self._spawnChest(template);
+                self._push([[Types.Messages.SPAWN,
+                              chest.id,
+                              chest.kind,
+                              chest.x,
+                              chest.y]]);
+            }, respawnDelay);
+        },
+
+        _dropForMob: function(mob) {
+            var self = this,
+                drops = [];
+
+            if(!mob || !mob.loot || mob.loot.length === 0) {
+                return drops;
+            }
+
+            var entry = mob.loot[mob.lootIndex % mob.loot.length];
+            mob.lootIndex += 1;
+
+            var kinds = _.isArray(entry) ? entry : [entry];
+            _.each(kinds, function(kind) {
+                var item = self._spawnItem(kind, mob.x, mob.y, [self.player.id]);
+                drops.push(item);
+            });
+
+            return drops;
+        },
+
+        _nextChestItems: function(chest) {
+            if(!chest || !chest.loot || chest.loot.length === 0) {
+                return [];
+            }
+            var entry = chest.loot[chest.lootIndex % chest.loot.length];
+            chest.lootIndex += 1;
+            return _.isArray(entry) ? entry : [entry];
+        },
+
+        _healPlayer: function(amount) {
+            if(this.player) {
+                this.player.hp = Math.min(this.player.maxHp, this.player.hp + amount);
+            }
+        },
+
+        _healingAmount: function(kind) {
+            switch(kind) {
+                case Types.Entities.FLASK:
+                    return 40;
+                case Types.Entities.BURGER:
+                    return 100;
+                case Types.Entities.CAKE:
+                    return 60;
+            }
+            return 0;
+        },
+
+        _computePlayerDamage: function(weaponKind, armor) {
+            var rank = Types.getWeaponRank(weaponKind);
+            return 10 + (rank * 5);
+        },
+
+        _computeMobDamage: function(base, armorKind) {
+            var mitigation = 2 * Types.getArmorRank(armorKind);
+            return Math.max(1, base - mitigation);
+        },
+
+        _computePlayerMaxHp: function(armorKind) {
+            return 100 + (Types.getArmorRank(armorKind) * 20);
+        },
+
+        _handlePlayerDeath: function(packets) {
+            var spawn = this.spawn || { x: 10, y: 10 };
+            this.player.x = spawn.x;
+            this.player.y = spawn.y;
+            this.player.hp = this.player.maxHp;
+            packets.push([Types.Messages.TELEPORT, this.player.id, this.player.x, this.player.y]);
+            packets.push([Types.Messages.HEALTH, this.player.hp, 1]);
+            this._resetMobTargets();
+        },
+
+        _resetMobTargets: function() {
+            var self = this;
+            _.each(this.mobs, function(mob) {
+                self._clearMobTarget(mob);
+            });
+        },
+
+        _clearMobTarget: function(mob) {
+            if(mob) {
+                mob.target = null;
+                mob.nextAttackTime = 0;
+            }
+        },
+
+        _nextEntityId: function() {
+            return this.nextEntityId++;
+        },
+
+        _isValidPosition: function(x, y) {
+            if(!this.map || !this.map.isColliding) {
+                return true;
+            }
+            return !this.map.isColliding(x, y);
+        },
+
+        _push: function(messages) {
+            if(this.pushCallback && messages && messages.length > 0) {
+                this.pushCallback(messages);
+            }
+        },
+
+        _updateMobs: function() {
+            var self = this;
+            _.each(this.mobs, function(mob) {
+                if(mob.isDead) {
+                    return;
+                }
+                self._updateMobTarget(mob);
+                self._updateMobMovement(mob);
+                self._updateMobAttack(mob);
+            });
+        },
+
+        _updateMobTarget: function(mob) {
+            if(!this.player) {
+                return;
+            }
+            var distance = this._distance(mob.x, mob.y, this.player.x, this.player.y);
+
+            if(!mob.target && distance <= (mob.aggroRange || this.mobAggroRange)) {
+                mob.target = this.player.id;
+                this._push([[Types.Messages.ATTACK, mob.id, this.player.id]]);
+            } else if(mob.target && distance > (mob.leashRange || this.mobLeashRange)) {
+                this._clearMobTarget(mob);
+            }
+        },
+
+        _updateMobMovement: function(mob) {
+            var target = mob.target ? this.entities[mob.target] : null;
+
+            if(target && target.id === this.player.id && this.player.hp > 0) {
+                var distance = this._distance(mob.x, mob.y, target.x, target.y);
+                if(distance > 1) {
+                    var next = this._stepTowards(mob.x, mob.y, target.x, target.y);
+                    if(next && this._isValidPosition(next.x, next.y)) {
+                        mob.x = next.x;
+                        mob.y = next.y;
+                        this._push([[Types.Messages.MOVE, mob.id, mob.x, mob.y]]);
+                    }
+                }
+            } else if(!mob.target && (mob.x !== mob.spawnX || mob.y !== mob.spawnY)) {
+                var home = this._stepTowards(mob.x, mob.y, mob.spawnX, mob.spawnY);
+                if(home && this._isValidPosition(home.x, home.y)) {
+                    mob.x = home.x;
+                    mob.y = home.y;
+                    this._push([[Types.Messages.MOVE, mob.id, mob.x, mob.y]]);
+                }
+            }
+        },
+
+        _updateMobAttack: function(mob) {
+            if(!mob.target || !this.player || this.player.hp <= 0) {
+                return;
+            }
+            if(mob.target !== this.player.id) {
+                return;
+            }
+            var distance = this._distance(mob.x, mob.y, this.player.x, this.player.y);
+            if(distance > 1) {
+                return;
+            }
+
+            var now = Date.now();
+            if(!mob.nextAttackTime || now >= mob.nextAttackTime) {
+                mob.nextAttackTime = now + (mob.attackDelay || this.mobAttackDelay);
+                this._push(this.handleHurt(mob.id));
+            }
+        },
+
+        _stepTowards: function(x1, y1, x2, y2) {
+            var dx = x2 - x1,
+                dy = y2 - y1,
+                stepX = x1,
+                stepY = y1;
+
+            if(dx === 0 && dy === 0) {
+                return null;
+            }
+
+            if(Math.abs(dx) >= Math.abs(dy)) {
+                stepX += dx > 0 ? 1 : -1;
+                if(this._isValidPosition(stepX, stepY)) {
+                    return { x: stepX, y: stepY };
+                }
+                stepX = x1;
+            }
+
+            if(dy !== 0) {
+                stepY += dy > 0 ? 1 : -1;
+                if(this._isValidPosition(stepX, stepY)) {
+                    return { x: stepX, y: stepY };
+                }
+            }
+
+            if(dx !== 0) {
+                stepX += dx > 0 ? 1 : -1;
+                if(this._isValidPosition(stepX, y1)) {
+                    return { x: stepX, y: y1 };
+                }
+            }
+            return null;
+        },
+
+        _distance: function(x1, y1, x2, y2) {
+            return Math.abs(x1 - x2) + Math.abs(y1 - y2);
+        }
+    });
+
+    return LocalWorld;
+});

--- a/docs/phase1_architecture.md
+++ b/docs/phase1_architecture.md
@@ -1,0 +1,36 @@
+# Phase 1 – Architecture Mapping
+
+## Module Graph Snapshot
+The current RequireJS client is organized around a small number of core entry points that we will have to preserve (or recreate) when tearing out AMD. The table below captures the highest-leverage modules we will need when packaging a single-file build.
+
+| Category | Module | Key dependencies | Notes |
+| --- | --- | --- | --- |
+| Bootstrapping | `client/js/main.js` | `jquery`, `app` | Wires DOM events for the intro UI and instantiates the `App` controller when the document is ready.【F:client/js/main.js†L2-L157】 |
+| Bootstrapping | `client/js/app.js` | `jquery`, `storage` | Owns the landing UI flow, localStorage-backed save slots, and the call into `game.run` once server options are selected.【F:client/js/app.js†L2-L200】 |
+| Core loop | `client/js/game.js` | Rendering, entities, networking modules | Houses renderer setup, map loading, entity lifecycle, achievement logic, and every network callback `GameClient` exposes.【F:client/js/game.js†L1-L1559】 |
+| Rendering | `client/js/renderer.js` | `camera`, `item`, `character`, `player`, `timer` | Maintains the canvas contexts, camera transforms, and dirty-rect drawing for both player-controlled and remote entities.【F:client/js/renderer.js†L1-L400】 |
+| World data | `client/js/map.js` | `jquery`, `area` | Loads client-side world JSON, exposes collision helpers, zone membership, and door metadata that the game loop consumes.【F:client/js/map.js†L1-L320】 |
+| Entities | `client/js/entity.js` + subclasses | Shared `character`, `mob`, `npc`, `player`, `item`, `chest` | Implements the sprite-driven state machines and provides event hooks such as `onStep`, `onDeath`, and `onLoot` that the game registers during handshake.【F:client/js/entity.js†L1-L360】【F:client/js/mob.js†L1-L200】【F:client/js/player.js†L1-L260】 |
+| Assets | `client/js/sprites.js` & `sprite.js` | AMD `text!` loaders for JSON atlases | `sprites.js` pulls every sprite atlas into memory, while `sprite.js` builds animation frames and hurt/loot variants that `Game` assigns per entity.【F:client/js/sprites.js†L1-L130】【F:client/js/sprite.js†L1-L240】 |
+| Networking | `client/js/gameclient.js` | `player`, `entityfactory`, `lib/bison` | Wraps WebSocket transport, message decoding, and a matrix of callbacks for entity, combat, loot, and chat updates.【F:client/js/gameclient.js†L1-L540】 |
+| Audio | `client/js/audio.js` | `area` | Declares positional music areas and effect playback hooks that `Game` triggers when zones or combat state change.【F:client/js/audio.js†L1-L200】 |
+| Persistence | `client/js/storage.js` | Browser `localStorage` | Manages persistent player records, kill counters, and achievement unlock state, which must survive in the single-file build.【F:client/js/storage.js†L1-L340】 |
+
+## Multiplayer Integration Points
+A precise list of network touch points will let us slot a deterministic “local server” behind the existing interfaces.
+
+- **Connection & dispatch** – `Game.connect` instantiates `GameClient`, optionally hits the dispatcher, and establishes the WebSocket link before kicking off the hello handshake.【F:client/js/game.js†L713-L748】  The dispatcher path relies on `GameClient.connect`’s two-mode WebSocket handler that either resolves a downstream host or enters normal game messaging.【F:client/js/gameclient.js†L47-L108】
+- **Entity discovery** – Upon connection, the client requests the active entity list and issues `sendWho` for unknown IDs, relying on `GameClient.receiveList` and spawn callbacks to populate the local entity grids.【F:client/js/game.js†L750-L807】【F:client/js/gameclient.js†L195-L239】
+- **Player handshake** – `onWelcome` finalizes the player ID/name, restores persistent cosmetics, registers all local player event hooks, and primes achievements before the loop starts.【F:client/js/game.js†L768-L938】
+- **Outgoing commands** – Movement, targeting, loot, aggression, teleport, chat, zoning, checkpoint checks, and combat hits all flow through dedicated `GameClient.send*` helpers that wrap `sendMessage` with the appropriate packet IDs.【F:client/js/game.js†L801-L941】【F:client/js/game.js†L1511-L2150】【F:client/js/gameclient.js†L110-L538】
+- **Incoming world state** – Spawn/despawn events hydrate `EntityFactory` records, while move, attack, loot, damage, equipment, and teleport messages update in-memory entities and trigger audio/achievement side effects.【F:client/js/game.js†L1058-L1560】【F:client/js/gameclient.js†L164-L361】
+- **Meta channels** – Population counts, disconnect notifications, and chat bubble routing round out the callback set and map directly to UI elements controlled by `App` and `InfoManager`.【F:client/js/game.js†L1468-L1560】【F:client/js/gameclient.js†L146-L361】
+
+These surfaces represent the contract our single-player simulation must emulate—both in shape (message arrays) and timing (callbacks invoked during the render/update loop).
+
+## Server Gameplay Boundaries to Mirror
+To retain BrowserQuest’s pacing and loot economy offline, we have to replicate the core of the Node-based world simulator inside the client.
+
+- **`WorldServer` lifecycle** – Initializes collections for players, mobs, chest areas, queues, and tick rates, then wires event handlers for player connect/enter/exit, mob aggression, and regeneration pulses.【F:server/js/worldserver.js†L22-L146】  Its `run` method loads `world_server.json`, seeds mob and chest areas, spawns static entities, and processes outgoing queues at 50 updates per second.【F:server/js/worldserver.js†L148-L214】
+- **Area controllers** – `MobArea` spawns mobs of a given type inside rectangular regions, reattaching world callbacks and scheduling respawns when the area empties.【F:server/js/mobarea.js†L6-L46】  `ChestArea` tracks rectangular trigger zones and chest spawn positions for reward drops.【F:server/js/chestarea.js†L6-L24】
+- **Message serialization** – `server/js/message.js` defines the exact array payloads for every action (`SPAWN`, `MOVE`, `ATTACK`, `DROP`, `CHAT`, etc.), providing the schema our local simulation must keep to preserve compatibility with existing handlers.【F:server/js/message.js†L13-L200】

--- a/docs/progress_log.md
+++ b/docs/progress_log.md
@@ -1,5 +1,12 @@
 # Development Progress Log
 
-- **2025-09-18 – Phase 1:** Catalogued the client module graph, enumerated multiplayer integration points, and documented the server world systems that must be reimplemented client-side for the single-player build.【F:docs/phase1_architecture.md†L1-L55】
-- **2025-09-19 – Phase 2 Kickoff:** Introduced a single-player toggle, local world simulation, and a `LocalGameClient` adapter to drive the existing game loop without WebSockets.【F:client/js/app.js†L1-L120】【F:client/js/game.js†L1-L200】【F:client/js/singleplayer/localgameclient.js†L1-L109】【F:client/js/singleplayer/world.js†L1-L220】
-- **2025-09-20 – Phase 2 Iteration:** Added timed mob AI, health regeneration, multi-item loot handling, and chest respawns to the local world simulator to better mirror server behavior.【F:client/js/singleplayer/world.js†L318-L520】【F:client/js/singleplayer/world.js†L596-L736】
+_Last updated: 2025-09-20_
+
+## 2025-09-18 – Phase 1 Architecture Blueprint
+Documented the client module graph, multiplayer touch points, and server-side world responsibilities that the single-player build must re-create, establishing the blueprint for the conversion effort.【F:docs/phase1_architecture.md†L1-L55】
+
+## 2025-09-19 – Phase 2 Local Simulation Kickoff
+Introduced a single-player toggle, `LocalGameClient` adapter, and an embedded world simulation so the existing game loop can run without WebSockets while preserving the current UI and systems.【F:client/js/app.js†L1-L120】【F:client/js/game.js†L1-L200】【F:client/js/singleplayer/localgameclient.js†L1-L109】【F:client/js/singleplayer/world.js†L1-L220】
+
+## 2025-09-20 – Phase 2 Local Simulation Iteration
+Expanded the local world simulator with timed mob AI, hero regeneration, multi-item loot handling, and chest respawns to mirror online server behavior more closely.【F:client/js/singleplayer/world.js†L318-L520】【F:client/js/singleplayer/world.js†L596-L736】

--- a/docs/progress_log.md
+++ b/docs/progress_log.md
@@ -1,0 +1,5 @@
+# Development Progress Log
+
+- **2025-09-18 – Phase 1:** Catalogued the client module graph, enumerated multiplayer integration points, and documented the server world systems that must be reimplemented client-side for the single-player build.【F:docs/phase1_architecture.md†L1-L55】
+- **2025-09-19 – Phase 2 Kickoff:** Introduced a single-player toggle, local world simulation, and a `LocalGameClient` adapter to drive the existing game loop without WebSockets.【F:client/js/app.js†L1-L120】【F:client/js/game.js†L1-L200】【F:client/js/singleplayer/localgameclient.js†L1-L109】【F:client/js/singleplayer/world.js†L1-L220】
+- **2025-09-20 – Phase 2 Iteration:** Added timed mob AI, health regeneration, multi-item loot handling, and chest respawns to the local world simulator to better mirror server behavior.【F:client/js/singleplayer/world.js†L318-L520】【F:client/js/singleplayer/world.js†L596-L736】


### PR DESCRIPTION
## Summary
- add timed loops for the single-player world simulator so mobs aggro, chase, and attack the player while the hero regenerates health over time
- allow mobs and chests to respawn and emit multiple drops, plus expose cleanup helpers for scheduled timers
- refresh the development progress log with updated citations and a new Phase 2 iteration entry

## Testing
- ./bin/build.sh *(fails: legacy r.js depends on deprecated `path.existsSync`, which is unavailable in the Node.js 20 runtime bundled in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1de587648331a2dacb4429c956d6